### PR TITLE
Turn off all colors for Pros

### DIFF
--- a/src/Dynamixel2Arduino.cpp
+++ b/src/Dynamixel2Arduino.cpp
@@ -557,6 +557,10 @@ bool Dynamixel2Arduino::setLedState(uint8_t id, bool state)
     case PRO_M42P_010_S260_R:
     case PRO_M54P_040_S250_R:
     case PRO_M54P_060_S250_R:
+          if (state == false) {
+              writeControlTableItem(ControlTableItem::LED_GREEN, id, state);
+              writeControlTableItem(ControlTableItem::LED_BLUE, id, state);
+          }
       ret = writeControlTableItem(ControlTableItem::LED_RED, id, state);
       break;
 


### PR DESCRIPTION
Using "ledOff" on Pros should turn all colors off. If Green or Blue is on, they also should be turned off.