### PR TITLE
Added comment to provide information on AX MX default use of protocol 1 communications.

### DIFF
--- a/examples/advanced/add_custom_SerialPortHandler/add_custom_SerialPortHandler.ino
+++ b/examples/advanced/add_custom_SerialPortHandler/add_custom_SerialPortHandler.ino
@@ -96,6 +96,8 @@ class NewSerialPortHandler : public DYNAMIXEL::SerialPortHandler
 };
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl;

--- a/examples/advanced/fast_sync_read/fast_sync_read.ino
+++ b/examples/advanced/fast_sync_read/fast_sync_read.ino
@@ -94,6 +94,8 @@ typedef struct InfoFastSyncReadInst{
 } __attribute__((packed)) InfoSyncWriteInst_t;
 */
 
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 1.0;
 const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const uint8_t BROADCAST_ID = 254;
 const uint8_t DXL_ID_CNT = 2;

--- a/examples/advanced/indirect_address/indirect_address.ino
+++ b/examples/advanced/indirect_address/indirect_address.ino
@@ -62,6 +62,8 @@
 
 
 const uint8_t BROADCAST_ID = 254;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 1.0;
 const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 
 const uint8_t DXL_ID_CNT = 2;

--- a/examples/advanced/pid_tuning/pid_tuning.ino
+++ b/examples/advanced/pid_tuning/pid_tuning.ino
@@ -60,6 +60,8 @@
 
 const uint8_t DXL_ID = 1;
 const uint32_t DXL_BAUDRATE = 57600;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 int32_t goal_position[2] = {1200, 1600};

--- a/examples/advanced/read_write_ControlTableItem/read_write_ControlTableItem.ino
+++ b/examples/advanced/read_write_ControlTableItem/read_write_ControlTableItem.ino
@@ -162,6 +162,8 @@ using namespace ControlTableItem;
 void setup() {
   // put your setup code here, to run once:
   DEBUG_SERIAL.begin(115200);
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: dxl.setPortProtocolVersion(2.0);
   dxl.setPortProtocolVersion(2.0);
   dxl.begin(57600);
   dxl.scan();

--- a/examples/advanced/slave/slave.ino
+++ b/examples/advanced/slave/slave.ino
@@ -85,6 +85,8 @@ void setup() {
   // Speed setting for communication (not necessary for USB)
   dxl_port.begin(1000000);
 
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: dxl.setPortProtocolVersion(DXL_PROTOCOL_VER_1_0);
   dxl.setPortProtocolVersion(DXL_PROTOCOL_VER_2_0);
   dxl.setFirmwareVersion(1);
   dxl.setID(1);

--- a/examples/advanced/slave_callback/slave_callback.ino
+++ b/examples/advanced/slave_callback/slave_callback.ino
@@ -85,6 +85,8 @@ void setup() {
   // Speed setting for communication (not necessary for USB)
   dxl_port.begin(1000000);
 
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: dxl.setPortProtocolVersion(DXL_PROTOCOL_VER_1_0);
   dxl.setPortProtocolVersion(DXL_PROTOCOL_VER_2_0);
   dxl.setFirmwareVersion(1);
   dxl.setID(1);

--- a/examples/advanced/sync_read_write_position/sync_read_write_position.ino
+++ b/examples/advanced/sync_read_write_position/sync_read_write_position.ino
@@ -99,6 +99,8 @@
 */
 
 const uint8_t BROADCAST_ID = 254;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const uint8_t DXL_ID_CNT = 2;
 const uint8_t DXL_ID_LIST[DXL_ID_CNT] = {1, 2};

--- a/examples/advanced/sync_read_write_velocity/sync_read_write_velocity.ino
+++ b/examples/advanced/sync_read_write_velocity/sync_read_write_velocity.ino
@@ -93,6 +93,8 @@
 */
 
 const uint8_t BROADCAST_ID = 254;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const uint8_t DXL_ID_CNT = 2;
 const uint8_t DXL_ID_LIST[DXL_ID_CNT] = {1, 2};

--- a/examples/basic/baudrate/baudrate.ino
+++ b/examples/basic/baudrate/baudrate.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 uint32_t BAUDRATE = 57600;
 uint32_t NEW_BAUDRATE = 1000000; //1Mbsp

--- a/examples/basic/current_mode/current_mode.ino
+++ b/examples/basic/current_mode/current_mode.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/current_position_mode/current_position_mode.ino
+++ b/examples/basic/current_position_mode/current_position_mode.ino
@@ -58,6 +58,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/id/id.ino
+++ b/examples/basic/id/id.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DEFAULT_DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/led/led.ino
+++ b/examples/basic/led/led.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/operation_mode/operation_mode.ino
+++ b/examples/basic/operation_mode/operation_mode.ino
@@ -64,6 +64,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/ping/ping.ino
+++ b/examples/basic/ping/ping.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/position_mode/position_mode.ino
+++ b/examples/basic/position_mode/position_mode.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/profile_velocity_acceleration/profile_velocity_acceleration.ino
+++ b/examples/basic/profile_velocity_acceleration/profile_velocity_acceleration.ino
@@ -59,6 +59,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/pwm_mode/pwm_mode.ino
+++ b/examples/basic/pwm_mode/pwm_mode.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/torque/torque.ino
+++ b/examples/basic/torque/torque.ino
@@ -58,6 +58,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/basic/velocity_mode/velocity_mode.ino
+++ b/examples/basic/velocity_mode/velocity_mode.ino
@@ -54,6 +54,8 @@
  
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/dynamixel_protocol/factory_reset/factory_reset.ino
+++ b/examples/dynamixel_protocol/factory_reset/factory_reset.ino
@@ -54,6 +54,8 @@
 
 #define TIMEOUT 10    //default communication timeout 10ms
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 bool ret = false;

--- a/examples/dynamixel_protocol/ping/ping.ino
+++ b/examples/dynamixel_protocol/ping/ping.ino
@@ -64,6 +64,8 @@ uint8_t ret = 0;
 uint8_t recv_count = 0;
 
 const uint8_t DXL_ID = BROADCAST_ID;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);

--- a/examples/dynamixel_protocol/reboot/reboot.ino
+++ b/examples/dynamixel_protocol/reboot/reboot.ino
@@ -54,6 +54,8 @@
 
 #define TIMEOUT 10    //default communication timeout 10ms
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 uint8_t option = 0;
 


### PR DESCRIPTION
Hopefully, this will make it easier for first time users that have AX/MX servos by providing clear instructions to change the active protocol version.