### PR TITLE
add support for STM32 native HalfDuplex mode

### DIFF
--- a/src/utility/port_handler.cpp
+++ b/src/utility/port_handler.cpp
@@ -58,6 +58,11 @@ void SerialPortHandler::begin(unsigned long baud)
     digitalWrite(dir_pin_, LOW);
     while(digitalRead(dir_pin_) != LOW);
   }
+#ifdef ARDUINO_ARCH_STM32
+  else{
+    port_.enableHalfDuplexRx();
+  }
+#endif  // ARDUINO_ARCH_STM32
 
   setOpenState(true);
 }
@@ -98,6 +103,11 @@ size_t SerialPortHandler::write(uint8_t c)
     digitalWrite(dir_pin_, LOW);
     while(digitalRead(dir_pin_) != LOW);
   }
+#ifdef ARDUINO_ARCH_STM32
+  else{
+    port_.enableHalfDuplexRx();
+  }
+#endif  // ARDUINO_ARCH_STM32
 
   return ret;
 }
@@ -120,6 +130,11 @@ size_t SerialPortHandler::write(uint8_t *buf, size_t len)
     digitalWrite(dir_pin_, LOW);
     while(digitalRead(dir_pin_) != LOW);
   }
+#ifdef ARDUINO_ARCH_STM32
+  else{
+    port_.enableHalfDuplexRx();
+  }
+#endif  // ARDUINO_ARCH_STM32
 
   return ret;      
 }


### PR DESCRIPTION
To be able to use the STM32 HalfDuplex mode, Rx has to be activated after each write. The HardwareSerial has to be intantiated as HalfDuplex by providing only one Pin to the constructor; i.e.: HardwareSerial Serial5(PA_0);

Signed-off-by: PerennialNovice