### PR TITLE
Fixes for timeout and erronous packets that cause firmware to crash

### DIFF
--- a/src/dxl_c/protocol.cpp
+++ b/src/dxl_c/protocol.cpp
@@ -701,6 +701,9 @@ static DXLLibErrorCode_t fast_parse_dxl2_0_packet(InfoToParseDXLPacket_t* p_pars
           && p_parse_packet->header[2] == 0xFD){
             p_parse_packet->recv_param_len = 0;
             p_parse_packet->calculated_crc = 0;
+            p_parse_packet->xel_index = 0;
+            p_parse_packet->buf_index = 0;
+
             update_dxl_crc(&p_parse_packet->calculated_crc, 0xFF);
             update_dxl_crc(&p_parse_packet->calculated_crc, 0xFF);
             update_dxl_crc(&p_parse_packet->calculated_crc, 0xFD);          

--- a/src/utility/master.cpp
+++ b/src/utility/master.cpp
@@ -1257,6 +1257,7 @@ const InfoToParseDXLPacket_t* Master::fastRxStatusPacket(InfoSyncReadInst_t* syn
       }
       if (millis()-pre_time_ms >= timeout_ms) {
         err = DXL_LIB_ERROR_TIMEOUT;
+        info_rx_packet_.parse_state = DXL2_0_PACKET_PARSING_STATE_IDLE;
         break;
       }
     }


### PR DESCRIPTION
- Changed `info_rx_packet_.parse_state` to `DXL2_0_PACKET_PARSING_STATE_IDLE` after a timeout to ensure it is reset correctly.
- Ensure that on every new packet, `xel_index` and `buf_index` are reset to zero. Right now, these are only reset to zero when a packet of a certain length is detected.