### PR TITLE
Added API for library error code

### DIFF
--- a/src/Dynamixel2Arduino.cpp
+++ b/src/Dynamixel2Arduino.cpp
@@ -155,6 +155,11 @@ unsigned long Dynamixel2Arduino::getPortBaud()
   return p_dxl_port_->getBaud();
 }
 
+int Dynamixel2Arduino::getLibErrCode()
+{
+  return getLastLibErrCode();
+}
+
 bool Dynamixel2Arduino::scan()
 {
   bool ret = true;

--- a/src/Dynamixel2Arduino.h
+++ b/src/Dynamixel2Arduino.h
@@ -94,6 +94,17 @@ class Dynamixel2Arduino : public DYNAMIXEL::Master
      * @return It returns serial baudrate of board port.
      */   
     unsigned long getPortBaud();
+
+    /**
+     * @brief API for getting library error code.
+     * @code
+     * const int DXL_DIR_PIN = 2;
+     * Dynamixel2Arduino dxl(Serial1, DXL_DIR_PIN);
+     * Serial.print(dxl.getErr());
+     * @endcode
+     * @return It returns error code from library.
+     */
+    int getLibErrCode();
     
     /**
      * @brief It is API for To checking the communication connection status of DYNAMIXEL.

--- a/src/Dynamixel2Arduino.h
+++ b/src/Dynamixel2Arduino.h
@@ -100,7 +100,7 @@ class Dynamixel2Arduino : public DYNAMIXEL::Master
      * @code
      * const int DXL_DIR_PIN = 2;
      * Dynamixel2Arduino dxl(Serial1, DXL_DIR_PIN);
-     * Serial.print(dxl.getErr());
+     * Serial.print(dxl.getLibErrCode());
      * @endcode
      * @return It returns error code from library.
      */


### PR DESCRIPTION
Added API function to retrieve library error code.

In line 158 to 161 in Dynamixel2Arduino.cpp
```c
int Dynamixel2Arduino::getLibErrCode()
{
  return getLastLibErrCode();
}
```

In line 98 to 107 in Dynamixel2Arduino.h
```c
/**
 * @brief API for getting library error code.
 * @code
 * const int DXL_DIR_PIN = 2;
 * Dynamixel2Arduino dxl(Serial1, DXL_DIR_PIN);
 * Serial.print(dxl.getErr());
 * @endcode
 * @return It returns error code from library.
 */
int getLibErrCode();
```